### PR TITLE
make compatible with older js engines

### DIFF
--- a/insist.js
+++ b/insist.js
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const assert = require('assert');
-const fs = require('fs');
+/*const*/ var assert = require('assert');
+/*const*/ var fs = require('fs');
 
-const esprima = require('esprima');
-const stack = require('stack-trace');
+/*const*/ var esprima = require('esprima');
+/*const*/ var stack = require('stack-trace');
 
-const NO_ASSERT = process.env.NO_ASSERT;
-const DONT_DECORATE = ['ok', 'fail', 'AssertionError'];
+/*const*/ var NO_ASSERT = process.env.NO_ASSERT;
+/*const*/ var DONT_DECORATE = ['ok', 'fail', 'AssertionError'];
 
 function noop() {}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insist",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Drop-in replacement of assert with a better message.",
   "main": "insist.js",
   "scripts": {


### PR DESCRIPTION
Replaced "const" with "var" so it can be used with older js engines.
(I'm using a recent js engine, but a nested esprima module is using older
syntax rules so it doesn't like the consts)