### PR TITLE
fix undefined dereference in getSource

### DIFF
--- a/insist.js
+++ b/insist.js
@@ -41,7 +41,7 @@ function getSource(trace) {
   var endLine = Infinity;
   var endCol = Infinity;
   traverse(tree, function(node) {
-    if (node.type === 'CallExpression') {
+    if (node && node.type === 'CallExpression') {
       if (node.loc.start.line > startLine || node.loc.start.col > startCol) {
         return;
       }


### PR DESCRIPTION
I was getting errors like this:

```
     TypeError: Cannot read property 'type' of undefined
      at node_modules/insist/insist.js:44:13
      at traverse (node_modules/insist/insist.js:17:3)
      at _traverseChild (node_modules/insist/insist.js:19:5)
      at Array.forEach (native)
      at traverse (node_modules/insist/insist.js:27:17)
      at _traverseChild (node_modules/insist/insist.js:19:5)
      at Array.forEach (native)
      at traverse (node_modules/insist/insist.js:27:17)
      at getSource (node_modules/insist/insist.js:43:3)
      at getMessage (node_modules/insist/insist.js:82:12)
      at Function.insist [as equal] (node_modules/insist/insist.js:96:22)
      at Context.it (test/local/routes/sms.js:585:14)
      at tryCatcher (node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (node_modules/bluebird/js/release/promise.js:510:31)
      at Promise._settlePromise (node_modules/bluebird/js/release/promise.js:567:18)
      at Promise._settlePromise0 (node_modules/bluebird/js/release/promise.js:612:10)
      at Promise._settlePromises (node_modules/bluebird/js/release/promise.js:691:18)
      at Async._drainQueue (node_modules/bluebird/js/release/async.js:133:16)
      at Async._drainQueues (node_modules/bluebird/js/release/async.js:143:10)
      at Immediate.Async.drainQueues (node_modules/bluebird/js/release/async.js:17:14)
```

No idea about a minimal test case, but they were occurring when I was trying to use part of the `aws-sdk` dependency that I haven't used before in `fxa-auth-server`. This change fixes the problem, but it doesn't add any new test coverage. Is it mergeable?